### PR TITLE
Feat/post detail page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,0 @@
-function App() {
-  return (
-    <div>
-      <h1 style={{ fontSize: '2rem', fontWeight: '700' }}>Rolling</h1>
-    </div>
-  );
-}
-
-export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import RootLayout from './router/RootLayout';
+import UserLayout from './router/UserLayout';
 import LandingPage from './pages/LandingPage';
 import ListPage from './pages/ListPage';
 import PostPage from './pages/PostPage';
@@ -26,11 +27,17 @@ const router = createBrowserRouter([
       },
       {
         path: 'post/:id',
-        element: <PostDetailPage />,
-      },
-      {
-        path: 'post/:id/edit',
-        element: <PostEditPage />,
+        element: <UserLayout />,
+        children: [
+          {
+            index: true,
+            element: <PostDetailPage />,
+          },
+          {
+            path: 'post/:id/edit',
+            element: <PostEditPage />,
+          },
+        ],
       },
       {
         path: 'post/:id/message',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ const router = createBrowserRouter([
             element: <PostDetailPage />,
           },
           {
-            path: 'post/:id/edit',
+            path: 'edit',
             element: <PostEditPage />,
           },
         ],

--- a/src/assets/style/reset.css
+++ b/src/assets/style/reset.css
@@ -150,13 +150,13 @@ input::-webkit-inner-spin-button {
   --green400: #60cf37;
   --green500: #2ba600;
 
-  --gary100: #f6f6f6;
-  --gary200: #eeeeee;
-  --gary300: #cccccc;
-  --gary400: #999999;
-  --gary500: #555555;
-  --gary600: #4a4a4a;
-  --gary700: #3a3a3a;
-  --gary800: #2b2b2b;
-  --gary900: #181818;
+  --gray100: #f6f6f6;
+  --gray200: #eeeeee;
+  --gray300: #cccccc;
+  --gray400: #999999;
+  --gray500: #555555;
+  --gray600: #4a4a4a;
+  --gray700: #3a3a3a;
+  --gray800: #2b2b2b;
+  --gray900: #181818;
 }

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const Card = styled.div`
+  width: 100%;
+  height: 280px;
+  padding: 28px 24px 24px;
+  border-radius: 16px;
+  background: var(--white);
+`;
+
+export default Card;

--- a/src/components/common/Section.jsx
+++ b/src/components/common/Section.jsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const Section = styled.section`
+  max-width: 1200px;
+  margin: 0 auto;
+`;
+
+export default Section;

--- a/src/components/post/MessageList.jsx
+++ b/src/components/post/MessageList.jsx
@@ -4,6 +4,7 @@ import Card from '../common/Card';
 const UserName = styled.article``;
 const CreateDate = styled.div``;
 const ListCard = styled(Card)``;
+// 데이터 받아 온 후 추가예정
 
 export default function MessageList({ userName }) {
   return (

--- a/src/components/post/MessageList.jsx
+++ b/src/components/post/MessageList.jsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import Card from '../common/Card';
+
+const UserName = styled.article``;
+const CreateDate = styled.div``;
+const ListCard = styled(Card)``;
+
+export default function MessageList({ userName }) {
+  return (
+    <ListCard>
+      <UserName>
+        <h2>{userName}</h2>
+        <span>tag</span>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Nesciunt,
+          nobis aperiam? Cupiditate expedita odit maxime eaque? Nam illum id
+          repellat.
+        </p>
+        <p>date</p>
+      </UserName>
+    </ListCard>
+  );
+}

--- a/src/components/post/PostDetail.jsx
+++ b/src/components/post/PostDetail.jsx
@@ -1,0 +1,55 @@
+import styled from 'styled-components';
+import MessageList from './MessageList';
+import Section from '../common/Section';
+
+export default function PostDetail() {
+  const Container = styled.div`
+    max-width: 1200px;
+    height: 100%;
+    margin: 0 auto;
+    @media (max-width: 1248px) {
+      padding: 0 24px;
+    }
+    @media (max-width: 640px) {
+      padding: 0 20px;
+    }
+  `;
+
+  const DetailSection = styled(Section)`
+    max-width: 100%;
+    margin-top: 13.3rem;
+    background: var(--green100);
+  `;
+
+  const FlexContainer = styled.div`
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2.4rem;
+    padding-top: 11.3rem;
+    padding-bottom: 24.6rem;
+    @media (max-width: 960px) {
+      grid-template-columns: repeat(2, 1fr);
+      padding-top: 9.3rem;
+      gap: 1.6rem;
+    }
+    @media (max-width: 640px) {
+      grid-template-columns: repeat(1, 1fr);
+      padding-top: 3.2rem;
+    }
+  `;
+
+  return (
+    <DetailSection>
+      <Container>
+        <FlexContainer>
+          <MessageList userName="admin" />
+          <MessageList userName="멍멍이" />
+          <MessageList userName="잔망루피" />
+          <MessageList userName="스프린트" />
+          <MessageList userName="흐음" />
+          <MessageList userName="테스트" />
+        </FlexContainer>
+      </Container>
+    </DetailSection>
+  );
+}

--- a/src/components/post/PostDetail.jsx
+++ b/src/components/post/PostDetail.jsx
@@ -2,42 +2,42 @@ import styled from 'styled-components';
 import MessageList from './MessageList';
 import Section from '../common/Section';
 
+const Container = styled.div`
+  max-width: 1200px;
+  height: 100%;
+  margin: 0 auto;
+  @media (max-width: 1248px) {
+    padding: 0 24px;
+  }
+  @media (max-width: 640px) {
+    padding: 0 20px;
+  }
+`;
+
+const DetailSection = styled(Section)`
+  max-width: 100%;
+  margin-top: 13.3rem;
+  background: var(--green100);
+`;
+
+const FlexContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2.4rem;
+  padding-top: 11.3rem;
+  padding-bottom: 24.6rem;
+  @media (max-width: 960px) {
+    grid-template-columns: repeat(2, 1fr);
+    padding-top: 9.3rem;
+    gap: 1.6rem;
+  }
+  @media (max-width: 640px) {
+    grid-template-columns: repeat(1, 1fr);
+    padding-top: 3.2rem;
+  }
+`;
+
 export default function PostDetail() {
-  const Container = styled.div`
-    max-width: 1200px;
-    height: 100%;
-    margin: 0 auto;
-    @media (max-width: 1248px) {
-      padding: 0 24px;
-    }
-    @media (max-width: 640px) {
-      padding: 0 20px;
-    }
-  `;
-
-  const DetailSection = styled(Section)`
-    max-width: 100%;
-    margin-top: 13.3rem;
-    background: var(--green100);
-  `;
-
-  const FlexContainer = styled.div`
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 2.4rem;
-    padding-top: 11.3rem;
-    padding-bottom: 24.6rem;
-    @media (max-width: 960px) {
-      grid-template-columns: repeat(2, 1fr);
-      padding-top: 9.3rem;
-      gap: 1.6rem;
-    }
-    @media (max-width: 640px) {
-      grid-template-columns: repeat(1, 1fr);
-      padding-top: 3.2rem;
-    }
-  `;
-
   return (
     <DetailSection>
       <Container>

--- a/src/components/post/UserHeader.jsx
+++ b/src/components/post/UserHeader.jsx
@@ -12,6 +12,7 @@ const UserInfo = styled.div`
   max-width: 1200px;
   margin: 0 auto;
 `;
+
 export default function UserHeader() {
   return (
     <UserContainer>

--- a/src/components/post/UserHeader.jsx
+++ b/src/components/post/UserHeader.jsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+const UserContainer = styled.div`
+  position: fixed;
+  top: 65px;
+  left: 0;
+  width: 100%;
+  height: 68px;
+  background: #ededed;
+`;
+const UserInfo = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+`;
+export default function UserHeader() {
+  return (
+    <UserContainer>
+      <UserInfo>
+        <h2>UserName</h2>
+      </UserInfo>
+    </UserContainer>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import ReactDOM from 'react-dom';
-import App from './App';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
 import '../src/assets/style/reset.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -1,3 +1,5 @@
+import Section from '../components/common/Section';
+
 export default function LandingPage() {
-  return <h1>LandingPage</h1>;
+  return <Section>LandingPage</Section>;
 }

--- a/src/pages/PostDetailPage.jsx
+++ b/src/pages/PostDetailPage.jsx
@@ -1,3 +1,5 @@
+import PostDetail from '../components/post/PostDetail';
+
 export default function PostDetailPage() {
-  return <h1>PostDetailPage</h1>;
+  return <PostDetail />;
 }

--- a/src/router/RootLayout.jsx
+++ b/src/router/RootLayout.jsx
@@ -1,5 +1,6 @@
 import { Outlet } from 'react-router-dom';
 import Header from '../ui/Header';
+
 export default function RootLayout() {
   return (
     <>

--- a/src/router/UserLayout.jsx
+++ b/src/router/UserLayout.jsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+import UserHeader from '../components/post/UserHeader';
+
+export default function UserLayout() {
+  return (
+    <>
+      <UserHeader />
+      <Outlet />
+    </>
+  );
+}

--- a/src/ui/Header.jsx
+++ b/src/ui/Header.jsx
@@ -18,7 +18,13 @@ export default function Header() {
 }
 
 const HeaderContainer = styled.header`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
   border-bottom: 1px solid #ededed;
+  background: var(--white);
 `;
 
 const Navigation = styled.nav`
@@ -28,10 +34,10 @@ const Navigation = styled.nav`
   max-width: 1200px;
   height: 65px;
   margin: 0 auto;
-  @media (max-width: 768px) {
+  @media (max-width: 1248px) {
     padding: 0 24px;
   }
-  @media (max-width: 360px) {
+  @media (max-width: 640px) {
     padding: 0 16px;
   }
 `;

--- a/src/ui/Header.jsx
+++ b/src/ui/Header.jsx
@@ -2,21 +2,6 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import logoImg from '../assets/image/logo.png';
 
-export default function Header() {
-  return (
-    <HeaderContainer>
-      <Navigation>
-        <div>
-          <Link to="/">
-            <img src={logoImg} alt="롤링 로고" />
-          </Link>
-        </div>
-        <Link to="/">롤링 페이퍼 만들기</Link>
-      </Navigation>
-    </HeaderContainer>
-  );
-}
-
 const HeaderContainer = styled.header`
   position: fixed;
   top: 0;
@@ -41,3 +26,18 @@ const Navigation = styled.nav`
     padding: 0 16px;
   }
 `;
+
+export default function Header() {
+  return (
+    <HeaderContainer>
+      <Navigation>
+        <div>
+          <Link to="/">
+            <img src={logoImg} alt="롤링 로고" />
+          </Link>
+        </div>
+        <Link to="/">롤링 페이퍼 만들기</Link>
+      </Navigation>
+    </HeaderContainer>
+  );
+}


### PR DESCRIPTION
### 구현 내용
- PostDetail 컴포넌트
- MessageList 컴포넌트
- User의 정보가 나오는 UserHeader 컴포넌트 (형태만)
- Card 컴포넌트
- Header 반응형 CSS 수정
- 컬러 팔레트 오타 수정

### 구현 설명
- 전체적으로 일단 모양만 잡혀있는 상태입니다.
- MessageList 컴포넌트는 message를 입력한 유저의 이름과 설정한 태그, 메세지 내용과 날짜를 받아올 컴포넌트 입니다.
- post/:id와 post/:id/edit을 가진 path들은 UserHeader에 중첩라우팅 되어있습니다.

### 스크린샷
![screencapture-localhost-3000-post-1-2024-07-14-15_11_20](https://github.com/user-attachments/assets/fd9e8070-4080-4092-bf66-5fb567434d69)

### 기타사항 및 건의사항
- 컬러 팔레트에 gray색상이 오타나서 오타 수정했습니다.. 키보드 최근에 바꿨더니 오타가 자주나네요.
- styled-component 들은 외부에서 정의 되는걸로 수정했습니다.
- 인재님이 올려주신 브랜치를 보니 css 부분과 라우터 path에서 " 와 ' 이 달라지는걸로 봐서 Prettier 설정이 다른거 같아 통일이 필요할 것 같습니다.