### PR TITLE
Feat/ Add message 컴포넌트들 추가 및 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-quill": "^2.0.0",
         "react-router-dom": "^6.24.1",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.11",
@@ -4179,6 +4180,14 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
       "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
     },
+    "node_modules/@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "dependencies": {
+        "parchment": "^1.1.2"
+      }
+    },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -5898,6 +5907,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/co": {
@@ -8055,10 +8072,20 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -12911,6 +12938,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -14407,6 +14439,75 @@
         }
       ]
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/quill-delta/node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quill/node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quill/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+    },
     "node_modules/quote-unquote": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
@@ -14696,6 +14797,20 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -20999,6 +21114,14 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
       "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
     },
+    "@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "requires": {
+        "parchment": "^1.1.2"
+      }
+    },
     "@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -22265,6 +22388,11 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
     "co": {
       "version": "4.6.0",
@@ -23829,10 +23957,20 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "fast-glob": {
       "version": "3.3.2",
@@ -27278,6 +27416,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -28230,6 +28373,64 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
+    "quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "requires": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+          "requires": {
+            "is-arguments": "^1.1.1",
+            "is-date-object": "^1.0.5",
+            "is-regex": "^1.1.4",
+            "object-is": "^1.1.5",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.5.1"
+          }
+        },
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+        }
+      }
+    },
+    "quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+          "requires": {
+            "is-arguments": "^1.1.1",
+            "is-date-object": "^1.0.5",
+            "is-regex": "^1.1.4",
+            "object-is": "^1.1.5",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.5.1"
+          }
+        }
+      }
+    },
     "quote-unquote": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
@@ -28447,6 +28648,16 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "requires": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      }
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-quill": "^2.0.0",
     "react-router-dom": "^6.24.1",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.11",

--- a/src/components/Input/NameInput.js
+++ b/src/components/Input/NameInput.js
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+
+const Input = styled.input`
+width: 720px;
+height: 50px;
+border: 1px solid var(--gray300);
+border-radius: 8px;
+padding: 12px 16px;
+font-size:16px;
+font-weight:400;
+line-height:26px;
+    `;
+
+function NameInput({ placeholder }) {
+
+    return (
+        <Input id="name" name="name" type="text" placeholder={placeholder} />
+    )
+
+}
+
+export default NameInput;

--- a/src/components/Input/NameInput.js
+++ b/src/components/Input/NameInput.js
@@ -11,10 +11,10 @@ font-weight:400;
 line-height:26px;
     `;
 
-function NameInput({ placeholder }) {
+function NameInput({ placeholder, onChange }) {
 
     return (
-        <Input id="name" name="name" type="text" placeholder={placeholder} />
+        <Input id="name" name="name" type="text" placeholder={placeholder} onChange={onChange} />
     )
 
 }

--- a/src/components/Post/AddMessage.js
+++ b/src/components/Post/AddMessage.js
@@ -1,115 +1,108 @@
+import { useState, useEffect } from "react";
 import styled from "styled-components";
 import Select from "../Select/Select";
+import Section from "../common/Section";
+import NameInput from "../Input/NameInput";
+import ContentArea from "../TextArea/ContentArea";
+import { getProfileImage } from "../../util/api";
+
+const Container = styled.form`
+display:flex;
+flex-direction: column;
+align-items: center;
+gap:50px;
+padding-top: 112px;
+`;
+
+const InputContainer = styled.div`
+display:flex;
+width: 720px; 
+flex-direction: column;
+gap:12px;
+`;
+
+const InputImageContainer = styled.div`
+display: flex;
+gap: 32px;
+`;
+
+const ImageContainer = styled.div`
+display: flex;
+flex-direction: column;
+gap:12px;
+`;
+
+const ImageLabel = styled.label`
+font-size: 16px;
+font-weight: 400;
+color: var(--gray500);
+`;
+
+const Images = styled.div`
+display: flex;
+`;
+
+const Title = styled.label`
+font-size: 24px;
+font-weight:700;
+`;
 
 function AddMessage() {
+    const relationshipOptions = ['지인', '친구', '동료', '가족'];
+    const fontOptions = ['Noto Sans', '폰트2'];
 
+    const [profileItem, setProfileItem] = useState([]);
 
-    const Container = styled.div`
-    display:flex;
-    flex-direction: column;
-   align-items: center;
-    gap:50px;
-    padding-top: 112px;
-    `;
+    const handleLoad = async () => {
+        const { imageUrls } = await getProfileImage();
+        setProfileItem(imageUrls);
+    }
 
-    const InputContainer = styled.div`
-    display:flex;
-    width: 720px; 
-    flex-direction: column;
-    gap:12px;
-    `;
+    useEffect(() => {
+        handleLoad();
+    }, []);
 
-    const InputImageContainer = styled.div`
-    display: flex;
-    gap: 32px;
-    `;
-
-    const ImageCantainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap:12px;
-    `;
-
-    const ImageLabel = styled.label`
-    font-size: 16px;
-    font-weight: 400;
-    color: var(--gray500);
-    `;
-
-    const Title = styled.label`
-    font-size: 24px;
-    font-weight:700;
-    `;
-
-    const Input = styled.input`
-    width: 720px;
-    height: 50px;
-    border: 1px solid var(--gray300);
-    border-radius: 8px;
-    padding: 12px 16px;
-    font-size:16px;
-    font-weight:400;
-    line-height:26px;
-        `;
-
-    const Content = styled.div`
-    width: 720px;
-    height: 260px;
-    `;
-
-    const ContentMunu = styled.div`
-    width: 720px;
-    height: 49px;
-    background-color: var(--gray300);
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
-    `;
-
-    const ContentTextArea = styled.textarea`
-    width: 720px;
-    height: 211px;
-    border: 1px solid var(--gray300);
-    border-top: none;
-    resize: none;
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
-    `;
+    useEffect(() => {
+        console.log(profileItem);
+    }, [profileItem])
 
     return (
-
-        <Container>
-            <InputContainer>
-                <Title>From.</Title>
-                <Input id="name" name="name" type="text" placeholder="이름을 입력해주세요."></Input>
-            </InputContainer>
-            <InputContainer>
-                <Title>프로필 이미지</Title>
-                <InputImageContainer>
-                    <img src="" alt="프로필 이미지" />
-                    <ImageCantainer>
-                        <ImageLabel>프로필 이미지를 선택해주세요!</ImageLabel>
-                        <img src="" alt="프로필 이미지" />
-                    </ImageCantainer>
-                </InputImageContainer>
-            </InputContainer>
-            <InputContainer>
-                <Title>상대와의 관계</Title>
-                <Select></Select>
-            </InputContainer>
-            <InputContainer>
-                <Title>내용을 입력해 주세요</Title>
-                <Content>
-                    <ContentMunu></ContentMunu>
-                    <ContentTextArea></ContentTextArea>
-                </Content>
-            </InputContainer>
-            <InputContainer>
-                <Title>폰트 선택</Title>
-                <Select></Select>
-            </InputContainer>
-            <button>생성하기</button>
-        </Container >
-
+        <Section>
+            <Container>
+                <InputContainer>
+                    <Title>From.</Title>
+                    <NameInput placeholder="이름을 입력해주세요."></NameInput>
+                </InputContainer>
+                <InputContainer>
+                    <Title>프로필 이미지</Title>
+                    <InputImageContainer>
+                        <img src={profileItem[0]} alt="프로필 이미지" />
+                        <ImageContainer>
+                            <ImageLabel>프로필 이미지를 선택해주세요!</ImageLabel>
+                            <Images>
+                                {profileItem.map((profile, index) => (
+                                    <img key={index} src={profile} />
+                                ))
+                                }
+                            </Images>
+                        </ImageContainer>
+                    </InputImageContainer>
+                </InputContainer>
+                <InputContainer>
+                    <Title>상대와의 관계</Title>
+                    <Select options={relationshipOptions} />
+                </InputContainer>
+                <InputContainer>
+                    <Title>내용을 입력해 주세요</Title>
+                    <ContentArea></ContentArea>
+                </InputContainer>
+                <InputContainer>
+                    <Title>폰트 선택</Title>
+                    <Select options={fontOptions} />
+                </InputContainer>
+                <button>생성하기</button>
+            </Container >
+        </Section>
     )
 }
 

--- a/src/components/Post/AddMessage.js
+++ b/src/components/Post/AddMessage.js
@@ -4,6 +4,7 @@ import Select from "../Select/Select";
 import Section from "../common/Section";
 import NameInput from "../Input/NameInput";
 import ContentArea from "../TextArea/ContentArea";
+import ProfileImageList from "../ProfileImageList/ProfileImageList";
 import { getProfileImage } from "../../util/api";
 
 const Container = styled.form`
@@ -26,22 +27,6 @@ display: flex;
 gap: 32px;
 `;
 
-const ImageContainer = styled.div`
-display: flex;
-flex-direction: column;
-gap:12px;
-`;
-
-const ImageLabel = styled.label`
-font-size: 16px;
-font-weight: 400;
-color: var(--gray500);
-`;
-
-const Images = styled.div`
-display: flex;
-`;
-
 const Title = styled.label`
 font-size: 24px;
 font-weight:700;
@@ -62,10 +47,6 @@ function AddMessage() {
         handleLoad();
     }, []);
 
-    useEffect(() => {
-        console.log(profileItem);
-    }, [profileItem])
-
     return (
         <Section>
             <Container>
@@ -76,16 +57,7 @@ function AddMessage() {
                 <InputContainer>
                     <Title>프로필 이미지</Title>
                     <InputImageContainer>
-                        <img src={profileItem[0]} alt="프로필 이미지" />
-                        <ImageContainer>
-                            <ImageLabel>프로필 이미지를 선택해주세요!</ImageLabel>
-                            <Images>
-                                {profileItem.map((profile, index) => (
-                                    <img key={index} src={profile} />
-                                ))
-                                }
-                            </Images>
-                        </ImageContainer>
+                        <ProfileImageList items={profileItem}></ProfileImageList>
                     </InputImageContainer>
                 </InputContainer>
                 <InputContainer>

--- a/src/components/Post/AddMessage.js
+++ b/src/components/Post/AddMessage.js
@@ -37,7 +37,11 @@ function AddMessage() {
     const fontOptions = ['Noto Sans', '폰트2'];
 
     const [profileItem, setProfileItem] = useState([]);
+    const [name, setName] = useState('');
 
+    const handleNameChange = (e) => {
+        setName(e.target.value);
+    };
     const handleLoad = async () => {
         const { imageUrls } = await getProfileImage();
         setProfileItem(imageUrls);
@@ -52,7 +56,7 @@ function AddMessage() {
             <Container>
                 <InputContainer>
                     <Title>From.</Title>
-                    <NameInput placeholder="이름을 입력해주세요."></NameInput>
+                    <NameInput placeholder="이름을 입력해주세요." onChange={handleNameChange} />
                 </InputContainer>
                 <InputContainer>
                     <Title>프로필 이미지</Title>

--- a/src/components/ProfileImageList/ProfileImageList.js
+++ b/src/components/ProfileImageList/ProfileImageList.js
@@ -1,14 +1,23 @@
 import styled from "styled-components";
+import { useEffect, useState } from "react";
 
 const InputImageContainer = styled.div`
 display: flex;
 gap: 32px;
+justify-content: space-around;
+align-items: center;
 `;
 
 const ImageContainer = styled.div`
 display: flex;
 flex-direction: column;
 gap:12px;
+`;
+
+const SelectedImage = styled.img`
+width: 80px;
+height: 80px;
+border-radius: 100px ;
 `;
 
 const ImageLabel = styled.label`
@@ -29,14 +38,27 @@ border-radius: 100px ;
 `
 
 function ProfileImageList({ items }) {
+
+    const [selectedSrc, setSelectedSrc] = useState(items[0]);
+
+    const handleImageSelect = (src) => {
+        setSelectedSrc(src);
+    };
+
+    useEffect(() => {
+        if (items.length > 0) {
+            setSelectedSrc(items[0]);
+        }
+    }, [items]);
+
     return (
         <InputImageContainer>
-            <img src={items[0]} alt="프로필 이미지" />
+            <SelectedImage src={selectedSrc} alt="프로필 이미지" />
             <ImageContainer>
                 <ImageLabel>프로필 이미지를 선택해주세요!</ImageLabel>
                 <Images>
                     {items.map((profile, index) => (
-                        <ImageChoose key={index} src={profile} />
+                        <ImageChoose key={index} src={profile} alt={`프로필 이미지 ${index + 1}`} onClick={() => handleImageSelect(profile)} />
                     ))
                     }
                 </Images>

--- a/src/components/ProfileImageList/ProfileImageList.js
+++ b/src/components/ProfileImageList/ProfileImageList.js
@@ -1,6 +1,48 @@
-function ProfileImageList() {
+import styled from "styled-components";
 
+const InputImageContainer = styled.div`
+display: flex;
+gap: 32px;
+`;
 
+const ImageContainer = styled.div`
+display: flex;
+flex-direction: column;
+gap:12px;
+`;
+
+const ImageLabel = styled.label`
+font-size: 16px;
+font-weight: 400;
+color: var(--gray500);
+`;
+
+const Images = styled.div`
+display: flex;
+gap: 5px;
+`;
+
+const ImageChoose = styled.img`
+width: 56px;
+height: 56px;
+border-radius: 100px ;
+`
+
+function ProfileImageList({ items }) {
+    return (
+        <InputImageContainer>
+            <img src={items[0]} alt="프로필 이미지" />
+            <ImageContainer>
+                <ImageLabel>프로필 이미지를 선택해주세요!</ImageLabel>
+                <Images>
+                    {items.map((profile, index) => (
+                        <ImageChoose key={index} src={profile} />
+                    ))
+                    }
+                </Images>
+            </ImageContainer>
+        </InputImageContainer>
+    )
 }
 
 export default ProfileImageList;

--- a/src/components/ProfileImageList/ProfileImageList.js
+++ b/src/components/ProfileImageList/ProfileImageList.js
@@ -1,0 +1,6 @@
+function ProfileImageList() {
+
+
+}
+
+export default ProfileImageList;

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -47,14 +47,14 @@ font-weight: 400;
 }
 `;
 
-function Select({ options, initialSelected }) {
+function Select({ options }) {
 
     const [isOpen, setIsOpen] = useState(false);
     const [selectedOption, setSelectedOption] = useState(options[0]);
 
 
     const toggleOptions = () => {
-        setIsOpen(!isOpen);
+        setIsOpen((prevIsOpen) => !prevIsOpen);
     };
 
     const handleOptionClick = (option) => {

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -3,55 +3,54 @@ import arrowTop from "../../assets/image/arrow_top.png"
 import arrowDown from "../../assets/image/arrow_down.png";
 import { useState } from "react";
 
-function Select() {
-
-    const Select = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 320px;
-    height: 50px;
-    border: 1px solid var(--gray300);
-    padding: 12px 16px;
-    border-radius: 8px;
-    box-sizing: border-box;
+const SelectWrapper = styled.div`
+display: flex;
+justify-content: space-between;
+align-items: center;
+width: 320px;
+height: 50px;
+border: 1px solid var(--gray300);
+padding: 12px 16px;
+border-radius: 8px;
 `;
 
-    const Image = styled.img`
-    width: 16px;
-    height: 16px;
+const Image = styled.img`
+width: 16px;
+height: 16px;
 `;
 
-    const Selected = styled.div`
-    display: flex;
-    font-size: 16px;
-    font-weight: 400;
+const Selected = styled.div`
+display: flex;
+font-size: 16px;
+font-weight: 400;
 
 `;
 
-    const Options = styled.ul`
-    position: absolute;
-    margin-top: 95px;
-    width: 318px;
-    border: 1px solid var(--gray300);
-    border-radius: 8px;
-    background-color: var(--white);
+const Options = styled.ul`
+position: absolute;
+margin-top: 95px;
+width: 318px;
+border: 1px solid var(--gray300);
+border-radius: 8px;
+background-color: var(--white);
 
 `;
 
-    const Option = styled.li`
-    padding: 12px 16px;
-    font-size: 16px;
-    font-weight: 400;
-    
-    &:hover {
-        background-color: var(--gray100);
-        cursor: pointer;
-    }
+const Option = styled.li`
+padding: 12px 16px;
+font-size: 16px;
+font-weight: 400;
+
+&:hover {
+    background-color: var(--gray100);
+    cursor: pointer;
+}
 `;
+
+function Select({ options, initialSelected }) {
 
     const [isOpen, setIsOpen] = useState(false);
-    const [selectedOption, setSelectedOption] = useState("aa");
+    const [selectedOption, setSelectedOption] = useState(options[0]);
 
 
     const toggleOptions = () => {
@@ -65,15 +64,17 @@ function Select() {
 
     return (
         <>
-            <Select onClick={toggleOptions}>
+            <SelectWrapper onClick={toggleOptions}>
                 <Selected>{selectedOption}</Selected>
-                <Image src={isOpen ? arrowTop : arrowDown}></Image>
-            </Select>
+                <Image src={isOpen ? arrowTop : arrowDown} />
+            </SelectWrapper>
 
             {isOpen && <Options>
-                <Option onClick={() => handleOptionClick("1")}>1</Option>
-                <Option onClick={() => handleOptionClick("2")}>2</Option>
-                <Option onClick={() => handleOptionClick("3")}>3</Option>
+                {options.map((option, index) => (
+                    <Option key={index} onClick={() => handleOptionClick(option)}>
+                        {option}
+                    </Option>
+                ))}
             </Options>
             }
         </>

--- a/src/components/TextArea/ContentArea.js
+++ b/src/components/TextArea/ContentArea.js
@@ -1,41 +1,65 @@
-import styled from "styled-components";
+import React, {
+    useMemo,
+    useState,
+    useRef
+} from 'react';
+import ReactQuill from 'react-quill';
 
-const Content = styled.div`
-width: 720px;
-height: 260px;
-`;
+import 'react-quill/dist/quill.snow.css';
 
-const ContentMenu = styled.div`
-width: 720px;
-height: 49px;
-background-color: var(--gray300);
-border-top-left-radius: 8px;
-border-top-right-radius: 8px;
-`;
+const formats = [
+    'font',
+    'header',
+    'bold',
+    'italic',
+    'underline',
+    'strike',
+    'blockquote',
+    'list',
+    'bullet',
+    'indent',
+    'link',
+    'align',
+    'color',
+    'background',
+    'size',
+    'h1',
+];
 
-const ContentTextArea = styled.textarea`
-width: 720px;
-height: 211px;
-border: 1px solid var(--gray300);
-border-top: none;
-resize: none;
-border-bottom-left-radius: 8px;
-border-bottom-right-radius: 8px;
-`;
 function ContentArea() {
+
+
+    const quillRef = useRef(null);
+    const [values, setValues] = useState();
+
+    const modules = useMemo(() => {
+        return {
+            toolbar: {
+                container: [
+                    ['bold', 'italic', 'underline', 'strike'],
+                    [{ align: [] }],
+                    [{ list: 'ordered' }, { list: 'bullet' }],
+                    [
+                        {
+                            color: [],
+                        },
+                        { background: [] },
+                    ],
+                ],
+            },
+        };
+    }, []);
+
     return (
-        <Content>
-            <ContentMenu>
-                <button>1</button>
-                <button>2</button>
-                <button>3</button>
-                <button>4</button>
-
-            </ContentMenu>
-            <ContentTextArea></ContentTextArea>
-        </Content>
+        <ReactQuill
+            ref={quillRef}
+            theme="snow"
+            modules={modules}
+            formats={formats}
+            onChange={setValues}
+            style={{ width: '100%', height: '200px', marginBottom: '50px' }}
+        />
     )
-
 }
 
 export default ContentArea;

--- a/src/components/TextArea/ContentArea.js
+++ b/src/components/TextArea/ContentArea.js
@@ -1,0 +1,41 @@
+import styled from "styled-components";
+
+const Content = styled.div`
+width: 720px;
+height: 260px;
+`;
+
+const ContentMenu = styled.div`
+width: 720px;
+height: 49px;
+background-color: var(--gray300);
+border-top-left-radius: 8px;
+border-top-right-radius: 8px;
+`;
+
+const ContentTextArea = styled.textarea`
+width: 720px;
+height: 211px;
+border: 1px solid var(--gray300);
+border-top: none;
+resize: none;
+border-bottom-left-radius: 8px;
+border-bottom-right-radius: 8px;
+`;
+function ContentArea() {
+    return (
+        <Content>
+            <ContentMenu>
+                <button>1</button>
+                <button>2</button>
+                <button>3</button>
+                <button>4</button>
+
+            </ContentMenu>
+            <ContentTextArea></ContentTextArea>
+        </Content>
+    )
+
+}
+
+export default ContentArea;

--- a/src/pages/AddMessagePage.jsx
+++ b/src/pages/AddMessagePage.jsx
@@ -1,4 +1,4 @@
-import AddMessage from "../components/Post/AddMessage";
+import AddMessage from '../components/Post/AddMessage';
 
 export default function AddMessagePage() {
   return <AddMessage></AddMessage>;

--- a/src/pages/AddMessagePage.jsx
+++ b/src/pages/AddMessagePage.jsx
@@ -1,5 +1,5 @@
 import AddMessage from '../components/Post/AddMessage';
 
 export default function AddMessagePage() {
-  return <AddMessage></AddMessage>;
+  return <AddMessage />;
 }

--- a/src/pages/PostDetailPage.jsx
+++ b/src/pages/PostDetailPage.jsx
@@ -1,4 +1,4 @@
-import PostDetail from '../components/post/PostDetail';
+import PostDetail from '../components/Post/PostDetail';
 
 export default function PostDetailPage() {
   return <PostDetail />;

--- a/src/router/UserLayout.jsx
+++ b/src/router/UserLayout.jsx
@@ -1,5 +1,5 @@
 import { Outlet } from 'react-router-dom';
-import UserHeader from '../components/post/UserHeader';
+import UserHeader from '../components/Post/UserHeader';
 
 export default function UserLayout() {
   return (

--- a/src/ui/Header.jsx
+++ b/src/ui/Header.jsx
@@ -32,11 +32,11 @@ export default function Header() {
     <HeaderContainer>
       <Navigation>
         <div>
-          <Link to="/">
-            <img src={logoImg} alt="롤링 로고" />
+          <Link to='/'>
+            <img src={logoImg} alt='롤링 로고' />
           </Link>
         </div>
-        <Link to="/">롤링 페이퍼 만들기</Link>
+        <Link to='/'>롤링 페이퍼 만들기</Link>
       </Navigation>
     </HeaderContainer>
   );

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -1,0 +1,7 @@
+const BASE_URL = 'https://rolling-api.vercel.app';
+
+export async function getProfileImage() {
+    const response = await fetch(`${BASE_URL}/profile-images/`);
+    const body = await response.json();
+    return body;
+}


### PR DESCRIPTION
**구현 내용**

- AddMessage 컴포넌트 리뷰사항들 일부를 수정했습니다.
- Select 컴포넌트에 디폴트 옵션들을 설정했습니다.
- Input 컴포넌트를 따로 분리시켜서 AddMessage로 가져오는 형식으로 변경하였습니다.
- ContentArea 컴포넌트를 따로 분리시켜 AddMessage로 가져오는 형식으로 변경하였습니다.
- ContentArea 컴포넌트에 'react-quill' 라이브러리를 설치하여 해당 부분을 구현하였습니다.
- 설치 명령어: npm i react-quill
- ProfileImageList 컴포넌트를 따로 분리시켜  AddMessage로 가져오는 형식으로 변경하였습니다.
- api파일을 생성하여 프로필 이미지들을 GET하는 함수를 만들고 ProfileImageList 컴포넌트에 출력시켰습니다.
- 이미지리스트를 클릭하면 프로필사진이 변경 되도록 하였습니다.

**구현 설명**

- 컴포넌트들을 간결하고 의미에 맞게 분리하는 작업을 하였습니다.

**스크린샷**
<img width="828" alt="image" src="https://github.com/user-attachments/assets/5467fcac-60e3-45f8-ac42-cb40eba4d3d7">
