### PR TITLE
Feat/ 생성하기버튼 공용컴포넌트로 변경, 반응형웹 추가

### DIFF
--- a/src/components/PostPage/AddPost.jsx
+++ b/src/components/PostPage/AddPost.jsx
@@ -72,7 +72,7 @@ const AddPost = () => {
           checkedTab={checkedTab}
           setCheckedTab={setCheckedTab}
         />
-        <SubmitButton disabled={isSubmitDisabled} />
+        <SubmitButton disabled={isSubmitDisabled}>생성하기</SubmitButton>
       </form>
     </PageWrap>
   );

--- a/src/components/PostPage/AddPost.jsx
+++ b/src/components/PostPage/AddPost.jsx
@@ -7,10 +7,15 @@ import styled from 'styled-components';
 import { RecipientMessageForm } from '../../util/api';
 
 const PageWrap = styled.div`
-  padding-top: 60px;
   max-width: 720px;
   margin: 0 auto;
-  margin-top: 60px;
+  margin-top: 95px;
+  box-sizing: border-box;
+
+  @media (max-width: 769px) {
+    margin-top: 26px;
+    padding: 24px 20px;
+  }
 `;
 
 const To = styled.h2`

--- a/src/components/PostPage/BgSelector.jsx
+++ b/src/components/PostPage/BgSelector.jsx
@@ -15,7 +15,7 @@ const Title = styled.h2`
   font-size: 24px;
   margin-bottom: 5px;
   font-weight: 700;
-  margin-top: 20px;
+  margin-top: 50px;
 `;
 
 const Description = styled.p`
@@ -45,9 +45,19 @@ const TabButton = styled.button`
 `;
 
 const OptionsWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  gap: 10px;
+  width: 100%;
+
+  @media (max-width: 768px) {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+
+  @media (min-width: 769px) {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-start;
+  }
 `;
 
 const BgSelector = ({

--- a/src/components/PostPage/ColorOption.jsx
+++ b/src/components/PostPage/ColorOption.jsx
@@ -2,27 +2,33 @@ import React from 'react';
 import styled from 'styled-components';
 
 const OptionWrap = styled.div`
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-  align-items: center;
-  width: 168px;
-  height: 168px;
-  border-radius: 10px;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 8px;
   background-color: ${(props) => props.color};
   cursor: pointer;
   position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  @media (min-width: 769px) {
+    width: 168px;
+    height: 168px;
+  }
 `;
 
 const CheckingMark = styled.div`
-  display: ${(props) => (props.selected ? 'block' : 'none')};
+  display: ${(props) => (props.selected ? 'flex' : 'none')};
   width: 44px;
   height: 44px;
   background-color: var(--gray500);
   border-radius: 50%;
-  position: absolute;
-  top: 62px;
-  left: 62px;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  font-size: 28px;
+  font-weight: 600;
   &:after {
     content: '✓';
     color: #fff;

--- a/src/components/PostPage/ImageOption.jsx
+++ b/src/components/PostPage/ImageOption.jsx
@@ -2,18 +2,28 @@ import React from 'react';
 import styled from 'styled-components';
 
 const ImageWrap = styled.div`
-  display: flex;
-  justify-content: center;
-  gap: 10px;
+  display: contents; //  ImageOption 컴포넌트의 구조 유지
+
+  @media (min-width: 769px) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: flex-start;
+  }
 `;
 
 const ImageCard = styled.div`
   position: relative;
-  width: 168px;
-  height: 168px;
-  border-radius: 5px;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 8px;
   cursor: pointer;
   overflow: hidden;
+
+  @media (min-width: 769px) {
+    width: calc(25% - 7.5px); // 4개의 아이템이 한 줄에 들어가도록 조정
+    max-width: 168px;
+  }
 
   img {
     width: 100%;
@@ -24,23 +34,23 @@ const ImageCard = styled.div`
 `;
 
 const CheckingMark = styled.div`
-  display: ${(props) => (props.selected ? 'block' : 'none')};
+  display: ${(props) => (props.selected ? 'flex' : 'none')};
   width: 44px;
   height: 44px;
   background-color: var(--gray500);
   border-radius: 50%;
   position: absolute;
-  top: 62px;
-  left: 62px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  justify-content: center;
+  align-items: center;
+
   &:after {
     content: '✓';
     color: #fff;
     font-size: 28px;
     font-weight: 600;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
   }
 `;
 

--- a/src/components/PostPage/SubmitButton.jsx
+++ b/src/components/PostPage/SubmitButton.jsx
@@ -12,6 +12,15 @@ const AddPostCommit = styled(PrimaryButton)`
     background-color: var(--gray300);
     cursor: not-allowed;
   }
+
+  @media (max-width: 1248px) {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% - 48px); // 좌우 여백 24px씩
+    max-width: 720px;
+  }
 `;
 
 const SubmitButton = ({ children, disabled, ...props }) => {

--- a/src/components/PostPage/SubmitButton.jsx
+++ b/src/components/PostPage/SubmitButton.jsx
@@ -1,29 +1,24 @@
 import React from 'react';
 import styled from 'styled-components';
+import PrimaryButton from '../common/PrimaryButton';
 
-const Button = styled.button`
-  background-color: ${({ disabled }) =>
-    disabled ? 'var(--gray500)' : 'var(--purple600)'};
+const AddPostCommit = styled(PrimaryButton)`
   width: 100%;
-  color: var(--white);
-  padding: 15px 30px;
   height: 56px;
-  border: none;
-  border-radius: 10px;
   font-size: 18px;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   margin-top: 70px;
-  &:hover {
-    background-color: ${({ disabled }) =>
-      disabled ? 'var(--gray500)' : 'var(--purple800)'};
+
+  &:disabled {
+    background-color: var(--gray300);
+    cursor: not-allowed;
   }
 `;
 
-const SubmitButton = ({ disabled }) => {
+const SubmitButton = ({ children, disabled, ...props }) => {
   return (
-    <Button type='submit' disabled={disabled}>
-      생성하기
-    </Button>
+    <AddPostCommit type='submit' disabled={disabled} {...props}>
+      {children}
+    </AddPostCommit>
   );
 };
 


### PR DESCRIPTION
## 💡구현내용
- 기존에 따로 사용하고있던 submitbutton을 공용 컴포넌트 primarybutton에서 불러와서 커스텀 했습니다.
- 모바일 반응형 추가했습니다.
- 타블렛 반응형 추가했습니다.
<br>

## 📃구현설명
- 개인적으로 쓰고있던 SubmitButton,jsx에서 primarybutton을 불러와 커스텀하는 식으로 작업했습니다.
- 모바일 크기가 됐을때 grid를 이용해서 배치했습니다.
` 요소의 크기를 비율대로 조정할 수 있게 하는 Aspect Ratio 속성을 사용해 화면이 줄어들어도 항상 1:1 비율을 유지할 수 있게 만들었습니다.`

<br>

## 📷스크린샷 및 구현영상
![수정완](https://github.com/user-attachments/assets/de9a5fd0-11ad-4697-8d85-ea514569952d)
- **버튼 공용컴포넌트로 변경**
<hr>

![tablet](https://github.com/user-attachments/assets/0ca2dd43-35ce-4ef5-a456-a7679da50429)
- **타블렛 반응형 구현**
<hr>

![mobile](https://github.com/user-attachments/assets/8b9649c0-2a51-433e-99ac-7211bedffa12)
- **모바일 반응형 구현**
<hr>

<br>

## ❓기타사항
