### PR TITLE
Feat/AddPostPage 모바일 이전 버튼추가

### DIFF
--- a/src/components/PostPage/AddPost.jsx
+++ b/src/components/PostPage/AddPost.jsx
@@ -18,6 +18,27 @@ const PageWrap = styled.div`
   }
 `;
 
+const BackButton = styled.button`
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  background-color: var(--error);
+  color: var(--white);
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  font-size: 16px;
+  cursor: pointer;
+  z-index: 1000;
+  &:hover {
+    background-color: #b63131;
+    transition: 0.2s all;
+  }
+  @media (min-width: 769px) {
+    display: none;
+  }
+`;
+
 const To = styled.h2`
   font-size: 24px;
   font-weight: 700;
@@ -31,6 +52,10 @@ const AddPost = () => {
   const [checkedTab, setCheckedTab] = useState('color');
   const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
   const navigate = useNavigate();
+
+  const handleGoBack = () => {
+    navigate(-1); // 이전 페이지로 이동
+  };
 
   useEffect(() => {
     setIsSubmitDisabled(valueName.trim() === '');
@@ -62,6 +87,7 @@ const AddPost = () => {
 
   return (
     <PageWrap>
+      <BackButton onClick={handleGoBack}>이전</BackButton>
       <form onSubmit={handleSubmit}>
         <To>To.</To>
         <NameInput


### PR DESCRIPTION
## 💡구현내용
- 모바일 상태일때 '이전'버튼을 추가했습니다.

<br>

## 📃구현설명
- 768px 이하일때 상단 헤더가 사라지기 때문에 우측 상단에 <이전> 버튼을 추가하여 이전 페이지로 돌아갈 수 있도록 구현했습니다.

<br>

## 📷스크린샷 및 구현영상
![이전](https://github.com/user-attachments/assets/5082ad44-19f5-431b-b8fb-539cc58a6586)

<br>

## ❓기타사항
