### PR TITLE
Feat/Notfound페이지반응형

### DIFF
--- a/src/components/PostPage/NotFoundPage.jsx
+++ b/src/components/PostPage/NotFoundPage.jsx
@@ -10,6 +10,14 @@ const Container = styled.form`
   gap: 30px;
   max-width: 720px;
   margin: 350px auto;
+  @media (max-width: 1248px) {
+    margin: 150px auto;
+    padding: 0 20px;
+  }
+
+  @media (max-width: 640px) {
+    margin: 150px auto;
+  }
 `;
 
 const MessageContainer = styled.div`
@@ -20,12 +28,26 @@ const MessageContainer = styled.div`
   gap: 15px;
 `;
 const ErrorTitle = styled.h1`
-  font-size: 200px;
+  font-size: 180px;
   color: var(--error);
+  @media (max-width: 1248px) {
+    font-size: 110px;
+  }
+
+  @media (max-width: 640px) {
+    font-size: 90px;
+  }
 `;
 
 const ErrorMessage = styled.h2`
   font-size: 35px;
+  @media (max-width: 1248px) {
+    font-size: 30px;
+  }
+
+  @media (max-width: 640px) {
+    font-size: 15px;
+  }
 `;
 
 const ErrorButton = styled(PrimaryButton)`
@@ -33,6 +55,15 @@ const ErrorButton = styled(PrimaryButton)`
   height: 60px;
   border-radius: 12px;
   font-size: 25px;
+  @media (max-width: 1248px) {
+  }
+
+  @media (max-width: 640px) {
+    border-radius: 5px;
+    width: 120px;
+    height: 45px;
+    font-size: 15px;
+  }
 `;
 
 function NotFoundPage() {


### PR DESCRIPTION
## 💡구현내용
- NotFoundPage의 반응형 디자인을 추가했습니다

<br>

## 📃구현설명
- 미디어 쿼리로 반응형 디자인을 추가했습니다 테블릿 너비이하일때 좌우 padding을 약간 넣고 폰트크기를 적절할 것 같은 사이즈로 변경했습니다.
- 정현님이 피드백해주셨던 에러 메세지 폰트를 약간 줄였습니다.

<br>

## 📷스크린샷 및 구현영상
- 너비 768px
<img width="763" alt="image" src="https://github.com/user-attachments/assets/6e81f583-a4e8-4f13-8600-27007ec25b38">

- 너비 360px
<img width="359" alt="image" src="https://github.com/user-attachments/assets/0c4dfcd0-ba4d-4e71-8a34-e176ccccf8b9">

<br>

## ❓기타사항
- 정의된 시안이 없는 페이지라 디자인적으로 필요한 부분도 피드백 받겠습니다!
