### PR TITLE
Feat/AddPostPage 탭 이미지 최적화 작업, 모바일화면 버튼 수정

### DIFF
--- a/src/components/PostPage/AddPost.jsx
+++ b/src/components/PostPage/AddPost.jsx
@@ -4,7 +4,7 @@ import NameInput from './NameInput';
 import BgSelector from './BgSelector';
 import SubmitButton from './SubmitButton';
 import styled from 'styled-components';
-import { RecipientMessageForm } from '../../util/api';
+import { recipientMessageForm } from '../../util/api';
 
 const PageWrap = styled.div`
   max-width: 720px;
@@ -76,7 +76,7 @@ const AddPost = () => {
     }
 
     try {
-      const response = await RecipientMessageForm(postData);
+      const response = await recipientMessageForm(postData);
       console.log('생성 완료:', response);
       navigate(`/post/${response.id}`);
     } catch (error) {

--- a/src/components/PostPage/BgSelector.jsx
+++ b/src/components/PostPage/BgSelector.jsx
@@ -70,10 +70,9 @@ const BgSelector = ({
   setCheckedTab,
 }) => {
   const [images, setImages] = useState([]);
-  const [isLoading, setIsLoading] = useState(true); // 로딩상태
+  const [isLoading, setIsLoading] = useState(true);
   const colors = ['beige', 'purple', 'blue', 'green'];
 
-  //프리로딩 함수
   const preloadImage = (url) => {
     return new Promise((resolve, reject) => {
       const img = new Image();
@@ -85,27 +84,25 @@ const BgSelector = ({
 
   useEffect(() => {
     const loadBackgroundImages = async () => {
-      setIsLoading(true); // 로딩 시작
+      setIsLoading(true);
       try {
-        const { thumbnailUrls, originalUrls } = await fetchBackgroundImages(
-          168
-        );
+        const { thumbnailUrls, originalUrls } = await fetchBackgroundImages();
         const imageData = thumbnailUrls.map((thumb, index) => ({
           thumbnail: thumb,
           original: originalUrls[index],
         }));
+
         setImages(imageData);
 
         if (originalUrls.length > 0 && !selectedImage) {
           setSelectedImage(originalUrls[0]);
         }
 
-        // 새로 추가: 썸네일 이미지 프리로딩
         await Promise.all(thumbnailUrls.map(preloadImage));
       } catch (error) {
         console.error('Error loading images:', error);
       } finally {
-        setIsLoading(false); // 로딩 완료
+        setIsLoading(false);
       }
     };
 

--- a/src/components/PostPage/ImageOption.jsx
+++ b/src/components/PostPage/ImageOption.jsx
@@ -65,7 +65,7 @@ const LoadingPlaceholder = styled.div`
 
 const ImageOption = ({ images, selectedImage, onSelect, isLoading }) => {
   if (isLoading) {
-    return <LoadingPlaceholder>Loading...</LoadingPlaceholder>; // 새로 추가: 로딩 중 표시
+    return <LoadingPlaceholder>Loading...</LoadingPlaceholder>;
   }
 
   return (
@@ -76,7 +76,7 @@ const ImageOption = ({ images, selectedImage, onSelect, isLoading }) => {
           selected={selectedImage === image.original}
           onClick={() => onSelect(image)}
         >
-          <img src={image.thumbnail} alt={'Background'} />
+          <img src={image.thumbnail} alt={'Background'} loading='lazy' />
           <CheckingMark
             selected={selectedImage === image.original}
           ></CheckingMark>

--- a/src/components/PostPage/ImageOption.jsx
+++ b/src/components/PostPage/ImageOption.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 const ImageWrap = styled.div`
-  display: contents; //  ImageOption 컴포넌트의 구조 유지
+  display: contents;
 
   @media (min-width: 769px) {
     display: flex;
@@ -21,7 +21,7 @@ const ImageCard = styled.div`
   overflow: hidden;
 
   @media (min-width: 769px) {
-    width: calc(25% - 7.5px); // 4개의 아이템이 한 줄에 들어가도록 조정
+    width: calc(25% - 7.5px);
     max-width: 168px;
   }
 
@@ -54,17 +54,32 @@ const CheckingMark = styled.div`
   }
 `;
 
-const ImageOption = ({ images, selectedImage, onSelect }) => {
+const LoadingPlaceholder = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: #f0f0f0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ImageOption = ({ images, selectedImage, onSelect, isLoading }) => {
+  if (isLoading) {
+    return <LoadingPlaceholder>Loading...</LoadingPlaceholder>; // 새로 추가: 로딩 중 표시
+  }
+
   return (
     <ImageWrap>
       {images.map((image, index) => (
         <ImageCard
           key={index}
-          selected={selectedImage === image}
+          selected={selectedImage === image.original}
           onClick={() => onSelect(image)}
         >
-          <img src={image} alt={'Background'} />
-          <CheckingMark selected={selectedImage === image}></CheckingMark>
+          <img src={image.thumbnail} alt={'Background'} />
+          <CheckingMark
+            selected={selectedImage === image.original}
+          ></CheckingMark>
         </ImageCard>
       ))}
     </ImageWrap>

--- a/src/components/PostPage/SubmitButton.jsx
+++ b/src/components/PostPage/SubmitButton.jsx
@@ -14,11 +14,6 @@ const AddPostCommit = styled(PrimaryButton)`
   }
 
   @media (max-width: 1248px) {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: calc(100% - 48px); // 좌우 여백 24px씩
     max-width: 720px;
   }
 `;

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -142,7 +142,7 @@ export async function deleteUser(id) {
   return response;
 }
 
-export const fetchBackgroundImages = async (thumbnailSize = 168) => {
+export const fetchBackgroundImages = async () => {
   try {
     const response = await fetch(
       'https://rolling-api.vercel.app/background-images/'
@@ -152,19 +152,14 @@ export const fetchBackgroundImages = async (thumbnailSize = 168) => {
     }
     const data = await response.json();
 
-    // 썸네일 URL 생성
-    const thumbnailUrls = data.imageUrls.map((url) => {
-      const parts = url.split('/');
-      parts.splice(-2); // 마지막 두 부분(원본 크기) 제거
-      return `${parts.join('/')}/${thumbnailSize}/${thumbnailSize}`;
-    });
+    const thumbnailUrls = data.imageUrls.map((url) => url);
 
     return {
       thumbnailUrls,
       originalUrls: data.imageUrls,
     };
   } catch (error) {
-    console.error('배경 이미지 :', error);
+    console.error('Error fetching background images:', error);
     return {
       thumbnailUrls: [],
       originalUrls: [],

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -100,7 +100,7 @@ export async function PostRecipientMessage({
   return body;
 }
 
-export async function RecipientMessageForm({
+export async function recipientMessageForm({
   name,
   backgroundColor,
   backgroundImageURL,
@@ -141,3 +141,33 @@ export async function deleteUser(id) {
   });
   return response;
 }
+
+export const fetchBackgroundImages = async (thumbnailSize = 168) => {
+  try {
+    const response = await fetch(
+      'https://rolling-api.vercel.app/background-images/'
+    );
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    const data = await response.json();
+
+    // 썸네일 URL 생성
+    const thumbnailUrls = data.imageUrls.map((url) => {
+      const parts = url.split('/');
+      parts.splice(-2); // 마지막 두 부분(원본 크기) 제거
+      return `${parts.join('/')}/${thumbnailSize}/${thumbnailSize}`;
+    });
+
+    return {
+      thumbnailUrls,
+      originalUrls: data.imageUrls,
+    };
+  } catch (error) {
+    console.error('배경 이미지 :', error);
+    return {
+      thumbnailUrls: [],
+      originalUrls: [],
+    };
+  }
+};


### PR DESCRIPTION
## 💡구현내용
- 탭 내부 썸네일 이미지들의 최적화 작업이 이루어졌습니다.
- 모바일 생성하기 버튼을 수정했습니다.

<br>

## 📃구현설명
- preloadImage 함수를 통해서 이미지 URL을 받아 해당 이미지를 미리 로드하고, 사용자가 이미지를 보기 전에 브라우저 캐시에 이미지를 저장하여 나중에 빠르게 표시할 수 있게 만들었습니다.
- 로딩상태를 표시해 어떤 상태인지 사용자에게 보여주고자 하였습니다.
- `await Promise.all(thumbnailUrls.map(preloadImage));` 함수를 통해 모든 썸네일 이미지를 동시에 프리로드하여  전체 로딩 시간을 단축했습니다.
- BgSelector에서 직접 다루던 api를 api.js로 빼내고, 멘토님이 말씀하신대로 무한로딩되지 않도록 리팩토링 했습니다.

<br>

## 📷스크린샷 및 구현영상
![ezgif-5-aa45a28f07](https://github.com/user-attachments/assets/d337d99b-f9a6-4f69-a775-5b1be66093f0)


<br>

## ❓기타사항
최대한 최적화를 하기 위해 썸네일 이미지를 168px로 불러왔었는데 모바일일땐 이미지가 더 크게 보여야해서 너무 화질이 떨어져 보였습니다. 추가작업을 하기엔 애매해서 사이즈 축소는 뺐습니다.
